### PR TITLE
Add tests for Integration Tests

### DIFF
--- a/config/devicelab_config.star
+++ b/config/devicelab_config.star
@@ -457,6 +457,7 @@ def devicelab_prod_config(branch, version, ref):
         "integration_ui_keyboard_resize",
         "integration_ui_screenshot",
         "integration_ui_textfield",
+        "integration_test_test",
         "microbenchmarks",
         "new_gallery__transition_perf",
         "picture_cache_perf__timeline_summary",
@@ -524,6 +525,7 @@ def devicelab_prod_config(branch, version, ref):
         "integration_ui_ios_keyboard_resize",
         "integration_ui_ios_screenshot",
         "integration_ui_ios_textfield",
+        "integration_test_test_ios"
         "ios_app_with_extensions_test",
         "ios_content_validation_test",
         "ios_defines_test",


### PR DESCRIPTION
Taking reference from `integration_ui_driver` and `integration_ui_ios_driver`. The tests were added in https://github.com/flutter/flutter/pull/79258